### PR TITLE
relax length constraint on rx_sample_read_frame value

### DIFF
--- a/lib/exbee/frames/rx_sample_read_frame.ex
+++ b/lib/exbee/frames/rx_sample_read_frame.ex
@@ -23,7 +23,7 @@ defmodule Exbee.RxSampleReadFrame do
     def decode(frame, encoded_binary) do
       case encoded_binary do
         <<0x92, mac_addr::64, network_addr::16, options::8, samples::8, digital_ch::16,
-          analog_ch::8, value::16>> ->
+          analog_ch::8, value::binary>> ->
           decoded_frame = %{
             frame
             | mac_addr: mac_addr,


### PR DESCRIPTION
Hi there!

Thanks for writing & publishing the exbee library!

While using it with some Digi L/T/H sensors[1] I have noticed that sensor-reported samples were not being decoded as the rx_sample_read_frame pattern matched against an exactly-16bit data value, but these sample lengths were longer.

I'm not sure there is necessarily a great reason to keep the value field hard-coded to 2 bytes, so I have attached a commit to this PR that relaxes the pattern match to essentially "the rest" of the data payload. This change allows 0x92 packets to be parsed correctly and contain L/T/H sensor values now.

1: https://www.digi.com/resources/documentation/digidocs/90001537/references/r_xbee_sensors.htm